### PR TITLE
Add command to switch this project to use a nightly compiler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ To get started, make sure you have `git`, `cargo` and, `rustc` installed and ava
 
 	git clone https://github.com/pbsds/gloom-rs
 	cd gloom-rs
+	rustup override set nightly
 	cargo run
 
 


### PR DESCRIPTION
if let chains are currently only available in nightly and the project uses them.
This should be reflected in the README.